### PR TITLE
Quotation fix attempt

### DIFF
--- a/src/extensions/jg_websiteRequests/index.js
+++ b/src/extensions/jg_websiteRequests/index.js
@@ -160,7 +160,7 @@ class JgWebsiteRequestBlocks {
             const fetchingUrl = args.WEBSITE.replace("rawRequest()", "");
             fetch(fetchingUrl, {cache: "no-cache"}).then(r => {
                 r.text().then(text => {
-                    resolve(String(text));
+                    resolve(text.toString());
                 })
                     .catch(() => {
                         resolve("");


### PR DESCRIPTION
When a server replies with a value from an object the extension includes the quotations from the response rather than treating it like a string. This is a possible fix, but good chance it's not and I'm stupid.
