### PR TITLE
add "set pen font weight to (weight)" block

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -91,7 +91,7 @@ class Scratch3PenBlocks {
          * @type {object}
          */
         this.printTextAttribute = {
-            bold: false,
+            weight: '400',
             underline: false,
             italic: false,
             size: '28',
@@ -426,6 +426,21 @@ class Scratch3PenBlocks {
                     arguments: {
                         COLOR: {
                             type: ArgumentType.COLOR
+                        }
+                    }
+                },
+                {
+                    opcode: 'setPrintFontWeight',
+                    blockType: BlockType.COMMAND,
+                    text: formatMessage({
+                        id: 'pen.setPrintFontWeight',
+                        default: 'set print font weight to [WEIGHT]',
+                        description: 'set print font weight'
+                    }),
+                    arguments: {
+                        WEIGHT: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: 700
                         }
                     }
                 },
@@ -854,11 +869,14 @@ class Scratch3PenBlocks {
         const hex = Color.rgbToHex(rgb);
         this.printTextAttribute.color = hex;
     }
-
+    setPrintFontWeight (args) {
+        this.printTextAttribute.weight = args.WEIGHT;
+    }
     printText (args) {
         const ctx = this._getBitmapCanvas();
 
         let resultFont = '';
+        resultFont += `${this.printTextAttribute.weight} `
         resultFont += `${this.printTextAttribute.size * this._penRes}px `;
         resultFont += this.printTextAttribute.font;
         ctx.font = resultFont;


### PR DESCRIPTION
replaced "bold" boolean with a numeric "weight". allows more control

adds a new block that controls the weight of the printed font, replacing the unused "bold" type