### PR TITLE
JSON Ext: Hide duplicate list blocks

### DIFF
--- a/src/extensions/jg_json/index.js
+++ b/src/extensions/jg_json/index.js
@@ -496,6 +496,7 @@ class JgJSONBlocks {
                             menu: 'lists'
                         }
                     },
+                    hideFromPalette: true,
                     text: 'get contents of list [list] as array'
                 },
                 {
@@ -512,6 +513,7 @@ class JgJSONBlocks {
                             defaultValue: "[\"A\", \"B\", \"C\"]"
                         }
                     },
+                    hideFromPalette: true,
                     text: 'set contents of list [list] to contents of array [array]'
                 }
             ],


### PR DESCRIPTION
Hides the 2 blocks that are duplicated by the category blocks.
![image](https://github.com/PenguinMod/PenguinMod-Vm/assets/127533508/3d73680d-cc92-4f41-bfef-cb86dd0454a6)
