### PR TITLE
Add direct Compiler access.

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -2249,6 +2249,10 @@ class IRGenerator {
         ir.procedures = this.procedures;
         return ir;
     }
+    
+    static exports = {
+        ScriptTreeGenerator
+    }
 }
 
 module.exports = IRGenerator;

--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -640,5 +640,7 @@ execute.scopedEval = scopedEval;
 execute.runtimeFunctions = runtimeFunctions;
 execute.saveGlobalState = saveGlobalState;
 execute.restoreGlobalState = restoreGlobalState;
+// not actually used, this is an export for extensions
+execute.globalState = globalState;
 
 module.exports = execute;

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -423,6 +423,13 @@ class JSGenerator {
         this.debug = this.target.runtime.debug;
     }
 
+    static exports = {
+        TypedInput,
+        ConstantInput,
+        VariableInput,
+        Frame
+    }
+
     static _extensionJSInfo = {};
     static setExtensionJs(id, data) {
         JSGenerator._extensionJSInfo[id] = data;

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -427,7 +427,18 @@ class JSGenerator {
         TypedInput,
         ConstantInput,
         VariableInput,
-        Frame
+        Frame,
+        VariablePool,
+        TYPE_NUMBER,
+        TYPE_STRING,
+        TYPE_BOOLEAN,
+        TYPE_UNKNOWN,
+        TYPE_NUMBER_NAN,
+        PEN_EXT,
+        PEN_STATE,
+        factoryNameVariablePool,
+        functionNameVariablePool,
+        generatorNameVariablePool
     }
 
     static _extensionJSInfo = {};

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -32,6 +32,10 @@ const Base64Util = require('./util/base64-util');
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
 const PM_LIBRARY_API = "https://library.penguinmod.com/";
 
+const IRGenerator = require('./compiler/irgen');
+const JSGenerator = require('./compiler/jsgen');
+const jsexecute = require('./compiler/jsexecute');
+
 const CORE_EXTENSIONS = [
     // 'motion',
     // 'looks',
@@ -236,7 +240,10 @@ class VirtualMachine extends EventEmitter {
         this.exports = {
             Sprite,
             RenderedTarget,
-            JSZip
+            JSZip,
+            JSGenerator,
+            IRGenerator,
+            jsexecute
         };
     }
 


### PR DESCRIPTION
### Resolves

Nothing

### Proposed Changes

Adds support for direct compiler access.

### Reason for Changes

So extensions can modify the compiler.

### Test Coverage

OG PR: https://github.com/TurboWarp/scratch-vm/pull/141/
PreBuilt: https://cst1229.github.io/scratch-gui/tw-ext-cblocks/editor.html
Just check the exports 👍 

PR's used (title not related):
    https://github.com/TurboWarp/scratch-vm/pull/141/commits/d0d527cd31863ee3a77b71b01ea2a2e02cf84c99
    https://github.com/TurboWarp/scratch-vm/pull/141/commits/ecec449b34915520616c1da87de1fd8293aaef32