### PR TITLE
Verify if the websocket is actually open before eveything

### DIFF
--- a/src/util/scratch-link-websocket.js
+++ b/src/util/scratch-link-websocket.js
@@ -95,8 +95,10 @@ class ScratchLinkWebSocket {
     }
 
     close () {
-        this._ws.close();
-        this._ws = null;
+        if (this.isOpen()) {
+            this._ws.close();
+            this._ws = null;
+        }
     }
 
     sendMessage (message) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes

_Try to fix an error that says: trying to close an websocket that hasnt been open_

### Reason for Changes

_I was doing my school project but for some reason it said the Lego EV3 was connected but it didnt move the parts so i got to the console and there it was the error_

### Test Coverage

_Please show how you have added tests to cover your changes_
