### PR TITLE
Create XML argument type

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1888,6 +1888,12 @@ class Runtime extends EventEmitter {
                 shadowType = (argTypeInfo.shadow && argTypeInfo.shadow.type) || null;
                 fieldName = (argTypeInfo.shadow && argTypeInfo.shadow.fieldName) || null;
             }
+            if (argInfo.type === 'xml' && typeof argInfo.xml === 'string') {
+                valueName = null;
+                shadowType = null;
+                fieldName = null;
+                context.inputList.push(argInfo.xml);
+            }
 
             // <value> is the ScratchBlocks name for a block input.
             if (valueName) {

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -77,7 +77,12 @@ const ArgumentType = {
      * @deprecated Not functioning as intended
      * @todo Fix menu resetting on update
      */
-    BROADCAST: 'broadcast'
+    BROADCAST: 'broadcast',
+
+    /**
+     * Arbitrary scratch-blocks XML.
+     */
+    XML: 'xml'
 };
 
 module.exports = ArgumentType;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes

Adds the XML argument type.

### Reason for Changes

Hiding the original block from the palette, and then creating a new xml block, while having to figure out what the XML of the block looks like is a pain... and all of that just to implement a default block for the argument? XML argument type would be much faster.

### Test Coverage

i havent, but im sure it works.
