### PR TITLE
make tempVars Object.create(null) instead of {}

### DIFF
--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -1699,7 +1699,7 @@ class JSGenerator {
             break;
         }
         case 'tempVars.deleteAll': {
-            this.source += `tempVars = {};`;
+            this.source += `tempVars = Object.create(null);`;
             break;
         }
         case 'tempVars.forEach': {
@@ -1934,7 +1934,7 @@ class JSGenerator {
             script += args.join(',');
         }
         script += ') {\n';
-        script += 'let tempVars = {};';
+        script += 'let tempVars = Object.create(null);';
 
         // pm: check if we are spoofing the target
         // ex: as (Sprite) {} block needs to replace the target

--- a/src/extensions/gsa_tempVars/index.js
+++ b/src/extensions/gsa_tempVars/index.js
@@ -17,7 +17,7 @@ class tempVars {
 
     getThreadVars (thread) {
         if (!thread.tempVars) {
-            thread.tempVars = {};
+            thread.tempVars = Object.create(null);
         }
         return thread.tempVars;
     }
@@ -213,7 +213,7 @@ class tempVars {
     
     deleteAllVariables (_, util) {
         // resets the vars
-        util.thread.tempVars = {};
+        util.thread.tempVars = Object.create(null);
     }
     
     variableExists (args, util) {


### PR DESCRIPTION
### Resolves

the fact that you can access Object.prototype from tempVars

### Proposed Changes

makes the tempVars object Object.create(null) instead of {}

### Reason for Changes

you can access Object.prototype from an empty tempVars object, which is likely not intended

### Test Coverage

...
