### PR TITLE
fix tempvars foreach

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -1805,6 +1805,7 @@ class ScriptTreeGenerator {
                 kind: 'tempVars.deleteAll'
             };
         case 'tempVars_forEachTempVar':
+            this.script.yields = true;
             return {
                 kind: 'tempVars.forEach',
                 var: this.descendInputOfBlock(block, 'NAME'),


### PR DESCRIPTION
### Resolves

https://discord.com/channels/1033551490331197462/1240267503536570388 
this bug

### Proposed Changes

adds `this.script.yields = true;` so that jsgen doesn't error when it reaches this.yieldLoop() cuz script isn't marked as yielding.

### Reason for Changes

fixes the bug?

### Test Coverage

idk but this is the bug
