### PR TITLE
fix the set prop of block

### DIFF
--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -1749,7 +1749,7 @@ class JSGenerator {
                 const costume = value.type === TYPE_NUMBER 
                     ? value.asNumber() 
                     : value.asString();
-                this.source += `runtime.ext_scratch3_looks._setCostume(${objectReference}, ${costume})`;
+                this.source += `runtime.ext_scratch3_looks._setCostume(${objectReference}, ${costume});`;
                 break;
             case 'backdrop':
                 const backdrop = value.type === TYPE_NUMBER 


### PR DESCRIPTION
### Resolves

Should resolve this issue reported in the discord server: https://discordapp.com/channels/1033551490331197462/1358294981130846389

### Proposed Changes

adds a singular semicolon

### Reason for Changes

identifiers immediately after the set prop of block (only when the prop specified is costume) are treated as syntax errors because the if statement has not been ended.

### Test Coverage

_Please show how you have added tests to cover your changes_
