### PR TITLE
Extension block switching

### DIFF
--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -84,7 +84,7 @@ function getSwitches({runtime}) {
                 return {
                     opcode: `${ext.id}_${current.opcode}`,
                     remapInputName: current.remapArguments ?? {},
-                    msg: get_block.info.switch_text ?? get_block.info.text
+                    msg: get_block.info.switchText ?? get_block.info.text
                 };
             });
         }

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -52,8 +52,44 @@ Object.getOwnPropertyNames(extensions).forEach(extID => {
     switches[extID] = extension;
 })
 
-function getSwitches() {
-    return switches;
+function getSwitches({runtime}) {
+    var _switches = switches;
+    for (let ext of runtime._blockInfo) {
+        _switches[ext.id] = {};
+        for (let block of ext.blocks) {
+            var blockswitches = block.info.switches;
+            if (!blockswitches) continue;
+            let opcode = block.json.type;
+            _switches[ext.id][opcode] = blockswitches.map(current => {
+                if (typeof current === "string") {
+                    current = {opcode: current}
+                } else if (typeof current !== "object") {
+                    return noopSwitch;
+                }
+
+                if (!("opcode" in current)) {
+                    return noopSwitch;
+                }
+
+                if (current.isNoop) {
+                    return noopSwitch;
+                }
+
+                let get_block = ext.blocks.filter(e => e.info.opcode === current.opcode);
+                if (get_block.length === 0) { // block doesn't exist.
+                    return noopSwitch;
+                }
+                get_block = get_block[0];
+
+                return {
+                    opcode: current.opcode,
+                    remapInputName: current.remapArguments ?? {},
+                    msg: get_block.info.switch_text
+                };
+            });
+        }
+    }
+    return _switches;
 }
 
 module.exports = getSwitches;

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -59,7 +59,7 @@ function getSwitches({runtime}) {
         for (let block of ext.blocks) {
             var blockswitches = block.info.switches;
             if (!blockswitches) continue;
-            let opcode = block.json.type;
+            let opcode = block.info.opcode;
             _switches[ext.id][opcode] = blockswitches.map(current => {
                 if (typeof current === "string") {
                     current = {opcode: current}
@@ -84,7 +84,7 @@ function getSwitches({runtime}) {
                 return {
                     opcode: current.opcode,
                     remapInputName: current.remapArguments ?? {},
-                    msg: get_block.info.switch_text
+                    msg: get_block.info.switch_text ?? get_block.info.text
                 };
             });
         }

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -82,7 +82,7 @@ function getSwitches({runtime}) {
                 get_block = get_block[0];
 
                 return {
-                    opcode: current.opcode,
+                    opcode: `${ext.id}_${current.opcode}`,
                     remapInputName: current.remapArguments ?? {},
                     msg: get_block.info.switch_text ?? get_block.info.text
                 };

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -223,7 +223,7 @@ const defaultBuiltinExtensions = {
     // griffpatch: () => require('../extensions/griffpatch_box2d')
 
     // iyg: erm a crep, erm a werdohhhh
-    // iygPerlin: 
+    // iygPerlin:
     iygPerlin: () => require('../extensions/iyg_perlin_noise'),
     // fr: waw 3d physics!!
     // fr3d:
@@ -359,7 +359,7 @@ class ExtensionManager {
     }
 
     getAddonBlockSwitches() {
-        return AddonSwitches();
+        return AddonSwitches(this.vm);
     }
 
     /**
@@ -476,7 +476,7 @@ class ExtensionManager {
             reader.readAsText(blob)
         })
         this.extensionHashes[extensionURL] = newHash
-        if (oldHash && oldHash !== newHash && this.securityManager.shouldUseLocal(extensionURL)) return Promise.reject('useLocal') 
+        if (oldHash && oldHash !== newHash && this.securityManager.shouldUseLocal(extensionURL)) return Promise.reject('useLocal')
 
         if (sandboxMode === 'unsandboxed') {
             const { load } = require('./tw-unsandboxed-extension-runner');
@@ -818,7 +818,7 @@ class ExtensionManager {
             blockInfo.xml = String(blockInfo.xml) || '';
             return blockInfo;
         }
-        
+
         blockInfo = Object.assign({}, {
             blockType: BlockType.COMMAND,
             terminal: false,

--- a/src/extension-support/extension-metadata.js
+++ b/src/extension-support/extension-metadata.js
@@ -26,7 +26,7 @@
  * @property {int} [branchCount] - for flow control blocks, the number of branches/substacks for this block.
  * @property {Object.<ExtensionArgumentMetadata>} [arguments] - map of argument placeholder to metadata about each arg.
  * @property {Array.<string|ExtensionBlockSwitchElement>} [switches] - array of the opcodes that this block is able to be swapped to.
- * @property {string} [switch_text] - text used for block switching
+ * @property {string} [switchText] - text used for block switching
  */
 
 /**

--- a/src/extension-support/extension-metadata.js
+++ b/src/extension-support/extension-metadata.js
@@ -25,7 +25,8 @@
  * @property {Boolean} [shouldRestartExistingThreads] - sets whether a hat/event block should restart existing threads.
  * @property {int} [branchCount] - for flow control blocks, the number of branches/substacks for this block.
  * @property {Object.<ExtensionArgumentMetadata>} [arguments] - map of argument placeholder to metadata about each arg.
- * @property {Array.<string>} [switches] - array of the opcodes that this block is able to be swapped to.
+ * @property {Array.<string|ExtensionBlockSwitchElement>} [switches] - array of the opcodes that this block is able to be swapped to.
+ * @property {string} [switch_text] - text used for block switching
  */
 
 /**
@@ -63,3 +64,11 @@
  * @property {*} value - the value of the block argument when this menu item is selected.
  * @property {string} text - the human-readable label of this menu item in the menu.
  */
+
+/**
+ * @typedef {object} ExtensionBlockSwitchElement
+ * A menu item for which the label and value can differ.
+ * @property {string} opcode - the opcode to switch to.
+ * @property {bool} isNoop - if this switch should be a noop.
+ * @property {Object.<string, string>} remapArguments - map of current block's arguments to this block's arguments.
+*/

--- a/src/extension-support/extension-metadata.js
+++ b/src/extension-support/extension-metadata.js
@@ -25,6 +25,7 @@
  * @property {Boolean} [shouldRestartExistingThreads] - sets whether a hat/event block should restart existing threads.
  * @property {int} [branchCount] - for flow control blocks, the number of branches/substacks for this block.
  * @property {Object.<ExtensionArgumentMetadata>} [arguments] - map of argument placeholder to metadata about each arg.
+ * @property {Array.<string>} [switches] - array of the opcodes that this block is able to be swapped to.
  */
 
 /**


### PR DESCRIPTION
Allows extensions to interact with the block switching addon.

It parses some private runtime stuff, but otherwise works fine. Probably could've done it in that addon rather than here, but this lets me update `src/extension-support/extension-metadata.js` to show it directly.

I still do need to submit a patch for the addon itself to update its block switch list when an extension is added.