### PR TITLE
Added more towards extension block switching.

### DIFF
--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -55,6 +55,7 @@ Object.getOwnPropertyNames(extensions).forEach(extID => {
 function getSwitches({runtime}) {
     var _switches = switches;
     for (let ext of runtime._blockInfo) {
+        if (ext.id in _switches) continue;
         _switches[ext.id] = {};
         for (let block of ext.blocks) {
             var blockswitches = block.info.switches;

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -90,7 +90,7 @@ function getSwitches({runtime}) {
                         let name = el.getAttribute("name");
                         let shadow_type = el.getElementsByName("shadow").getAttribute("type");
 
-                        let value = get_block.info.arguments[name].defaultValue ?? currargs[name] ?? "";
+                        let value = currargs[name] ?? get_block.info.arguments[name].defaultValue ?? "";
 
                         createInputs[name] = {
                             shadow_type,

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -84,11 +84,14 @@ function getSwitches({runtime}) {
                 let createInputs = {};
                 let currargs = current.createArguments ?? {};
 
-                new DOMParser().parseFromString(get_block.xml, "text/xml")
+                const parser = new DOMParser();
+
+                parser.parseFromString(get_block.xml, "text/xml")
                     .querySelectorAll(`[type="${get_block.json.type}"] > value`)
                     .forEach(el => {
                         let name = el.getAttribute("name");
-                        console.log(name);
+                        if (Object.keys(block.info.arguments).includes(name)) return;
+
                         let shadowType = el.getElementsByTagName("shadow")[0].getAttribute("type");
 
                         let value = (currargs[name] ?? get_block.info.arguments[name].defaultValue ?? "").toString();
@@ -102,11 +105,37 @@ function getSwitches({runtime}) {
                 const splitInputs = Object.keys(block.info.arguments)
                     .filter(arg => !Object.keys(get_block.info.arguments).includes(arg) && !Object.keys(current.remapArguments ?? {}).includes(arg));
 
+                const remapShadowType = {};
+
+                parser.parseFromString(block.xml, "text/xml")
+                    .querySelectorAll(`[type="${block.json.type}"] > value`)
+                    .forEach(el => {
+                        let name = el.getAttribute("name");
+                        if (!(name in get_block.info.arguments)) return;
+                        let shadowType = el.getElementsByTagName("shadow")[0].getAttribute("type");
+                        remapShadowType[name] = shadowType;
+                    });
+
+                parser.parseFromString(get_block.xml, "text/xml")
+                    .querySelectorAll(`[type="${get_block.json.type}"] > value`)
+                    .forEach(el => {
+                        let name = el.getAttribute("name");
+                        if (!(name in remapShadowType)) return;
+                        let shadowType = el.getElementsByTagName("shadow")[0].getAttribute("type");
+
+                        if (remapShadowType[name] == shadowType) {
+                            delete remapShadowType[name];
+                            return;
+                        }
+                        remapShadowType[name] = shadowType;
+                    });
+
                 return {
                     opcode: `${ext.id}_${current.opcode}`,
                     remapInputName: current.remapArguments ?? {},
                     createInputs,
                     splitInputs,
+                    remapShadowType,
                     mapFieldValues: current.remapMenus ?? {},
                     msg: get_block.info.switchText ?? get_block.info.text
                 };

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -84,22 +84,23 @@ function getSwitches({runtime}) {
                 let createInputs = {};
                 let currargs = current.createArguments ?? {};
 
-                new DOMParser().parseFromString(get_block.xml)
+                new DOMParser().parseFromString(get_block.xml, "text/xml")
                     .querySelectorAll(`[type="${get_block.json.type}"] > value`)
                     .forEach(el => {
                         let name = el.getAttribute("name");
-                        let shadow_type = el.getElementsByName("shadow").getAttribute("type");
+                        console.log(name);
+                        let shadowType = el.getElementsByTagName("shadow")[0].getAttribute("type");
 
-                        let value = currargs[name] ?? get_block.info.arguments[name].defaultValue ?? "";
+                        let value = (currargs[name] ?? get_block.info.arguments[name].defaultValue ?? "").toString();
 
                         createInputs[name] = {
-                            shadow_type,
+                            shadowType,
                             value
                         };
                     });
 
                 const splitInputs = Object.keys(block.info.arguments)
-                    .filter(arg => !Object.keys(get_block.info.arguments).includes(arg));
+                    .filter(arg => !Object.keys(get_block.info.arguments).includes(arg) && !Object.keys(current.remapArguments ?? {}).includes(arg));
 
                 return {
                     opcode: `${ext.id}_${current.opcode}`,

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -98,10 +98,14 @@ function getSwitches({runtime}) {
                         };
                     });
 
+                const splitInputs = Object.keys(block.info.arguments)
+                    .filter(arg => !Object.keys(get_block.info.arguments).includes(arg));
+
                 return {
                     opcode: `${ext.id}_${current.opcode}`,
                     remapInputName: current.remapArguments ?? {},
                     createInputs,
+                    splitInputs,
                     mapFieldValues: current.remapMenus ?? {},
                     msg: get_block.info.switchText ?? get_block.info.text
                 };

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -81,9 +81,28 @@ function getSwitches({runtime}) {
                 }
                 get_block = get_block[0];
 
+                let createInputs = {};
+                let currargs = current.createArguments ?? {};
+
+                new DOMParser().parseFromString(get_block.xml)
+                    .querySelectorAll(`[type="${get_block.json.type}"] > value`)
+                    .forEach(el => {
+                        let name = el.getAttribute("name");
+                        let shadow_type = el.getElementsByName("shadow").getAttribute("type");
+
+                        let value = get_block.info.arguments[name].defaultValue ?? currargs[name] ?? "";
+
+                        createInputs[name] = {
+                            shadow_type,
+                            value
+                        };
+                    });
+
                 return {
                     opcode: `${ext.id}_${current.opcode}`,
                     remapInputName: current.remapArguments ?? {},
+                    createInputs,
+                    mapFieldValues: current.remapMenus ?? {},
                     msg: get_block.info.switchText ?? get_block.info.text
                 };
             });


### PR DESCRIPTION
The previous PR was merged. This PR allows for more of the stuff in there to be set.

Some of these have been automated. Mainly, `remapShadowType` and `splitInputs` aren't necessary, and neither is needing to input your default values nor your shadow type for a block into `createArguments`. You only need to use create arguments if you'd like to change the input. Not much else in the way of automation can be done, unfortunately.

`remapMenus` can now be set to remap menu values. 