### PR TITLE
Extension block switching: Overwritting messages and better isNoop.

### DIFF
--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -68,7 +68,7 @@ function getSwitches({runtime}) {
                     return noopSwitch;
                 }
 
-                if (current.isNoop) {
+                if ("isNoop" in current && current.isNoop) {
                     return {
                         isNoop: true,
                         msg: current.overwriteText ?? block.info.switchText ?? block.info.text

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -68,11 +68,14 @@ function getSwitches({runtime}) {
                     return noopSwitch;
                 }
 
-                if (!("opcode" in current)) {
-                    return noopSwitch;
+                if (current.isNoop) {
+                    return {
+                        isNoop: true,
+                        msg: current.overwriteText ?? block.info.switchText ?? block.info.text
+                    };
                 }
 
-                if (current.isNoop) {
+                if (!("opcode" in current)) {
                     return noopSwitch;
                 }
 
@@ -138,7 +141,7 @@ function getSwitches({runtime}) {
                     splitInputs,
                     remapShadowType,
                     mapFieldValues: current.remapMenus ?? {},
-                    msg: get_block.info.switchText ?? get_block.info.text
+                    msg: current.overwriteText ?? get_block.info.switchText ?? get_block.info.text,
                 };
             });
         }


### PR DESCRIPTION
Before, when a user would set isNoop to true it wouldn't include a message, now it does.

Additionally, every block switch entry can manually overwrite text if need-be. May be useful in some circumstances.