### PR TITLE
Add compat. for i will not ask for help when these break and JSGen unstable_exports

### DIFF
--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -94,7 +94,7 @@ class TypedInput {
         if (this.type === TYPE_STRING) return `${this.source} === 'false' || ${this.source} === '0' ? false : true`;
         if (this.type === TYPE_NUMBER) return `${this.source} !== 0`;
         if (this.type === TYPE_NUMBER_NAN) return `(${this.source} || 0) !== 0`;
-        
+
         return this.source;
     }
 
@@ -436,8 +436,11 @@ class JSGenerator {
         PEN_STATE,
         factoryNameVariablePool,
         functionNameVariablePool,
-        generatorNameVariablePool
+        generatorNameVariablePool,
+        sanitize,
     }
+
+    static unstable_exports = JSGenerator.exports;
 
     static _extensionJSInfo = {};
     static setExtensionJs(id, data) {
@@ -554,7 +557,7 @@ class JSGenerator {
                     .replace(yn, this.descendInput(point.y).asNumber());
             }
             return new TypedInput(points, TYPE_UNKNOWN);
-            
+
         case 'control.inlineStackOutput': {
             // reset this.source but save it
             const originalSource = this.source;
@@ -644,14 +647,14 @@ class JSGenerator {
             return new TypedInput('runtime.ioDevices.mouse.getScratchX()', TYPE_NUMBER);
         case 'mouse.y':
             return new TypedInput('runtime.ioDevices.mouse.getScratchY()', TYPE_NUMBER);
-            
+
         case 'op.true':
             return new TypedInput('(true)', TYPE_BOOLEAN);
         case 'op.false':
             return new TypedInput('(false)', TYPE_BOOLEAN);
         case 'op.randbool':
             return new TypedInput('(Boolean(Math.round(Math.random())))', TYPE_BOOLEAN);
-            
+
         case 'pmEventsExpansion.broadcastFunction':
             // we need to do function otherwise this block would be stupidly long
             let source = '(yield* (function*() {';
@@ -956,7 +959,7 @@ class JSGenerator {
 
         case 'var.get':
             return this.descendVariable(node.variable);
-                
+
         case 'procedures.call': {
             const procedureCode = node.code;
             const procedureVariant = node.variant;
@@ -998,14 +1001,14 @@ class JSGenerator {
 
         case 'tempVars.get': {
             const name = this.descendInput(node.var);
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
-            const code = this.isOptimized 
-                ? `${hostObj}[${name.asString()}]` 
-                : `get(${hostObj}, ${name.asString()})`; 
+            const code = this.isOptimized
+                ? `${hostObj}[${name.asString()}]`
+                : `get(${hostObj}, ${name.asString()})`;
             if (environment.supportsNullishCoalescing) {
                 return new TypedInput(`(${code} ?? "")`, TYPE_UNKNOWN);
             }
@@ -1013,21 +1016,21 @@ class JSGenerator {
         }
         case 'tempVars.exists': {
             const name = this.descendInput(node.var);
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
-            const code = this.isOptimized 
-                ? `${name.asString()} in ${hostObj}` 
-                : `includes(${hostObj}, ${name.asString()})`; 
+            const code = this.isOptimized
+                ? `${name.asString()} in ${hostObj}`
+                : `includes(${hostObj}, ${name.asString()})`;
             return new TypedInput(code, TYPE_BOOLEAN);
         }
         case 'tempVars.all':
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
             if (node.runtime || node.thread) {
                 return new TypedInput(`Object.keys(${hostObj}).join(',')`, TYPE_STRING);
@@ -1321,7 +1324,7 @@ class JSGenerator {
             const stage = 'runtime.getTargetForStage()';
             const sprite = this.descendInput(node.sprite).asString();
             const isStage = sprite === '"_stage_"';
-            
+
             // save the original target
             const originalTarget = this.localVariables.next();
             this.source += `const ${originalTarget} = target;\n`;
@@ -1417,9 +1420,9 @@ class JSGenerator {
             const list = this.referenceVariable(node.list);
             const set = this.descendVariable(node.variable);
             const to = node.num ? 'index + 1' : 'value';
-            this.source += 
-            `for (let index = 0; index < ${list}.value.length; index++) {` + 
-                `const value = ${list}.value[index];` + 
+            this.source +=
+            `for (let index = 0; index < ${list}.value.length; index++) {` +
+                `const value = ${list}.value[index];` +
                 `${set.source} = ${to};`;
             this.descendStack(node.do, new Frame(true, 'list.forEach'));
             this.source += `};\n`;
@@ -1481,7 +1484,7 @@ class JSGenerator {
         case 'list.show':
             this.source += `runtime.monitorBlocks.changeBlock({ id: "${sanitize(node.list.id)}", element: "checkbox", value: true }, runtime);\n`;
             break;
-        
+
         case 'list.filter':
             this.source += `${this.referenceVariable(node.list)}.value = ${this.referenceVariable(node.list)}.value.filter(function* (item, index) {`;
             this.source += `    runtime.ext_scratch3_data._listFilterItem = item;`;
@@ -1656,7 +1659,7 @@ class JSGenerator {
             this.source += `${PEN_EXT}._penUp(target);\n`;
             break;
 
-        case 'procedures.return': 
+        case 'procedures.return':
             this.source += `return ${this.descendInput(node.return).asUnknown()};`;
             break;
         case 'procedures.call': {
@@ -1726,7 +1729,7 @@ class JSGenerator {
             // blocks like legacy no-ops can return a literal `undefined`
             this.source += `if (${value} !== undefined) runtime.visualReport("${sanitize(this.script.topBlockId)}", ${value});\n`;
             break;
-        }        
+        }
         case 'sensing.set.of': {
             const object = this.descendInput(node.object).asString();
             const value = this.descendInput(node.value);
@@ -1751,14 +1754,14 @@ class JSGenerator {
                 this.source += `${objectReference}.setDirection(${value.asNumber()});`;
                 break;
             case 'costume':
-                const costume = value.type === TYPE_NUMBER 
-                    ? value.asNumber() 
+                const costume = value.type === TYPE_NUMBER
+                    ? value.asNumber()
                     : value.asString();
                 this.source += `runtime.ext_scratch3_looks._setCostume(${objectReference}, ${costume});`;
                 break;
             case 'backdrop':
-                const backdrop = value.type === TYPE_NUMBER 
-                    ? value.asNumber() 
+                const backdrop = value.type === TYPE_NUMBER
+                    ? value.asNumber()
                     : value.asString();
                 this.source += `runtime.ext_scratch3_looks._setBackdrop(${objectReference}, ${backdrop});`;
                 break;
@@ -1777,33 +1780,33 @@ class JSGenerator {
         case 'tempVars.set': {
             const name = this.descendInput(node.var);
             const val = this.descendInput(node.val);
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
-            this.source += this.isOptimized  
-                ? `${hostObj}[${name.asString()}] = ${val.asUnknown()};` 
-                : `set(${hostObj}, ${name.asString()}, ${val.asUnknown()});`; 
+            this.source += this.isOptimized
+                ? `${hostObj}[${name.asString()}] = ${val.asUnknown()};`
+                : `set(${hostObj}, ${name.asString()}, ${val.asUnknown()});`;
             break;
         }
         case 'tempVars.delete': {
             const name = this.descendInput(node.var);
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
-            this.source += this.isOptimized  
-                ? `delete ${hostObj}[${name.asString()}];` 
-                : `remove(${hostObj}, ${name.asString()});`;  
+            this.source += this.isOptimized
+                ? `delete ${hostObj}[${name.asString()}];`
+                : `remove(${hostObj}, ${name.asString()});`;
             break;
         }
         case 'tempVars.deleteAll': {
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
             this.source += `${hostObj} = Object.create(null);`;
             break;
@@ -1811,18 +1814,18 @@ class JSGenerator {
         case 'tempVars.forEach': {
             const name = this.descendInput(node.var);
             const loops = this.descendInput(node.loops);
-            const hostObj = node.runtime 
-                ? 'runtime.variables' 
-                : node.thread 
-                    ? 'thread.variables' 
+            const hostObj = node.runtime
+                ? 'runtime.variables'
+                : node.thread
+                    ? 'thread.variables'
                     : 'tempVars';
-            const rootVar = this.localVariables.next(); 
-            const keyVar = this.localVariables.next(); 
-            const index = this.isOptimized  
-                ? `${hostObj}[${name.asString()}]` 
-                : `${rootVar}[${keyVar}]`; 
-            if (!this.isOptimized)  
-                this.source += `const [${rootVar},${keyVar}] = _resolveKeyPath(${hostObj}, ${name.asString()}); `; 
+            const rootVar = this.localVariables.next();
+            const keyVar = this.localVariables.next();
+            const index = this.isOptimized
+                ? `${hostObj}[${name.asString()}]`
+                : `${rootVar}[${keyVar}]`;
+            if (!this.isOptimized)
+                this.source += `const [${rootVar},${keyVar}] = _resolveKeyPath(${hostObj}, ${name.asString()}); `;
             this.source += `${index} = 0; `;
             this.source += `while (${index} < ${loops.asNumber()}) { `;
             this.source += `${index}++;\n`;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -242,7 +242,7 @@ class VirtualMachine extends EventEmitter {
         this.addListener('workspaceUpdate', () => {
             this.extensionManager.refreshDynamicCategorys();
         });
-        
+
         /**
          * Export some internal classes for extensions.
          */
@@ -259,8 +259,18 @@ class VirtualMachine extends EventEmitter {
             StageLayering,
             Variable,
             Thread: require('./engine/thread.js'),
-            execute: require('./engine/execute.js')
+            execute: require('./engine/execute.js'),
         };
+
+        this.exports.i_will_not_ask_for_help_when_these_break = () => {
+            return {
+                IRGenerator: IRGenerator,
+                JSGenerator,
+                ScriptTreeGenerator: IRGenerator.exports.ScriptTreeGenerator,
+                Thread: this.exports.Thread,
+                execute: this.exports.execute
+            }
+        }
     }
 
     /**
@@ -471,7 +481,7 @@ class VirtualMachine extends EventEmitter {
                     const decoder = new TextDecoder('UTF-8');
                     input = decoder.decode(input);
                 }
-                if (typeof input === 'string') 
+                if (typeof input === 'string')
                     input = JSON.parse(input);
                 // generic objects return [object Object] on stringify
                 if (input.toString() === '[object Object]') {
@@ -771,7 +781,7 @@ class VirtualMachine extends EventEmitter {
         return this._loadExtensions(extensions.extensionIDs, extensions.extensionURLs).then(() => {
             for (const extension of extensions.extensionIDs) {
                 if (`ext_${extension}` in this.runtime) {
-                    if ((typeof this.runtime[`ext_${extension}`].deserialize === 'function') && 
+                    if ((typeof this.runtime[`ext_${extension}`].deserialize === 'function') &&
                         extensions.extensionData[extension]) {
                         this.runtime[`ext_${extension}`].deserialize(extensions.extensionData[extension]);
                     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -262,7 +262,22 @@ class VirtualMachine extends EventEmitter {
             execute: require('./engine/execute.js'),
         };
 
+        /**
+         * For comptatibility with TurboWarp's
+         * i_will_not_ask_for_help_when_these_break export.
+         */
         this.exports.i_will_not_ask_for_help_when_these_break = () => {
+            console.info(
+                'Note on i_will_not_ask_for_help_when_these_break: this function is ' +
+                'only included for compatibility with TurboWarp, and you should avoid ' +
+                'using it when possible.\n' +
+                'All indexes are able to be accessed from the regular vm.exports ' +
+                'property. Below is a map of all elements here to their vm.exports ' +
+                'counterpart:\n' +
+                'IRGenerator -> IRGenerator\nJSGenerator -> JSGenerator\nThread -> Thread\n' +
+                'execute -> execute\n' +
+                'ScriptTreeGenerator -> IRGenerator.exports.ScriptTreeGenerator'
+            );
             return {
                 IRGenerator: IRGenerator,
                 JSGenerator,

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -279,7 +279,7 @@ class VirtualMachine extends EventEmitter {
                 'ScriptTreeGenerator -> IRGenerator.exports.ScriptTreeGenerator'
             );
             return {
-                IRGenerator: IRGenerator,
+                IRGenerator,
                 JSGenerator,
                 ScriptTreeGenerator: IRGenerator.exports.ScriptTreeGenerator,
                 Thread: this.exports.Thread,


### PR DESCRIPTION
I noticed that [Mistium's Tables extension](https://extensions.mistium.com/) wouldn't load, so I looked into why and found that it was using some low-level APIs from TurboWarp that, while having similar APIs available in PenguinMod, weren't used in Tables, thus meaning that it wouldn't load in PenguinMod.

To fix this, this PR adds support for the extension by adding `i_will_not_ask_for_help_when_these_break` under `vm.exports` and mirrors the content of `JSGenerator.exports` to `JSGenerator.unstable_exports`. I also added the `sanitize` function to `JSGenerator.exports`, even though it had pretty much nothing to do with supporting the Tables extension because I noticed that sanitize was missing from the exports.

There are no direct rips from the codebase of TurboWarp and no breaking changes included within this PR. There also aren't any related PRs that would need to be merged along with this one.