### PR TITLE
Only warn extensions once

### DIFF
--- a/src/util/deprecated-extension-storage.js
+++ b/src/util/deprecated-extension-storage.js
@@ -1,13 +1,27 @@
 /**
- * Creates an ExtensionStorage Proxy object that adds a warning to console when extensionStorage is updated.
- * The purpose is so that it can yell at extension developers to not use extensionStorage.
+ * @overview
+ * Utility for creating a proxy object that warns extension authors to not use the runtime.extensionStorage
+ * or target.extensionStorage APIs, as they're both deprecated.
+ */
+
+/**
+ * A set of extensions that have been warned. A set is used for performance reasons.
+ */
+const WARNED_EXTENSIONS = new Set();
+
+/**
+ * Creates the actual proxy object.
+ * @param {object.<string, any>} [default_content] Used by the deserializer to set the values of extensionStorage.
  */
 const ExtensionStorage = (default_content = {}) => {
   return new Proxy(
     default_content,
     {
       set: function (target, key, value) {
-        console.warn("extensionStorage APIs are deprecated. Please avoid using them in your extensions.");
+        if (!WARNED_EXTENSIONS.has(key)) {
+            console.warn("extensionStorage APIs are deprecated. Please avoid using them in your extensions.");
+            WARNED_EXTENSIONS.add(key);
+        }
         return target[key] = value;
       },
     }


### PR DESCRIPTION
Only warns extension developers not to use `extensionStorage` once.