### PR TITLE
Ext. block switching patch

### DIFF
--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -1,114 +1,136 @@
+const log = require('../util/log');
 const switches = {};
+const parser = new DOMParser();
 
-const noopSwitch = {
-    isNoop: true
+const define_error_noop = (msg) => {
+    log.error(msg);
+    return {
+        msg,
+        isNoop: true,
+        isError: true,
+    };
+};
+
+function get_extension_switches(id, blocks) {
+    let _switches = {};
+    for (let block of blocks) {
+        var blockswitches = block.info.switches;
+        if (!blockswitches) continue;
+        let opcode = block.info.opcode;
+        _switches[opcode] = blockswitches.map(current => {
+            switch (typeof current) {
+                case "object":
+                    break;
+                case "string":
+                    current = { opcode: current };
+                    break;
+                default:
+                    return define_error_noop((typeof current) + " disallowed");
+            }
+
+            if (current.isNoop) {
+                return {
+                    isNoop: true,
+                    msg: current.overwriteText ?? block.info.switchText ?? block.info.text
+                };
+            }
+
+            if (!current.opcode) {
+                return define_error_noop("No defined opcode");
+            }
+
+            let get_block = blocks.find(e => e.info.opcode === current.opcode);
+            if (!get_block) {
+                return define_error_noop(`Block ${current.opcode} doesn't exist`);
+            }
+
+            let createInputs = {};
+            let currargs = current.createArguments ?? {};
+
+            parser.parseFromString(get_block.xml, "text/xml")
+                .querySelectorAll(`[type="${get_block.json.type}"] > value`)
+                .forEach(el => {
+                    let name = el.getAttribute("name");
+                    if (
+                        !!block.info.arguments[name]
+                        && !(current.remapArguments ?? {})[name]
+                    ) return;
+                    if (Object.values(current.remapArguments ?? {}).includes(name)) return;
+
+                    let shadowType = el.getElementsByTagName("shadow")[0].getAttribute("type");
+
+                    let value = (currargs[name] ?? get_block.info.arguments[name].defaultValue ?? "").toString();
+
+                    createInputs[name] = {
+                        shadowType,
+                        value
+                    };
+                });
+
+            const splitInputs = Object.keys(block.info.arguments)
+                .filter(arg =>
+                    !!get_block.info.arguments[arg]
+                    && !!(current.remapArguments ?? {})[arg]
+                );
+
+            const remapShadowType = {};
+
+            parser.parseFromString(block.xml, "text/xml")
+                .querySelectorAll(`[type="${block.json.type}"] > value`)
+                .forEach(el => {
+                    let name = el.getAttribute("name");
+                    if ((current.remapArguments ?? {})[name]) name = current.remapArguments[name];
+                    if (!get_block.info.arguments[name]) return;
+
+                    let shadowType = el.querySelector("shadow")
+                    if (!shadowType) return;
+                    shadowType = shadowType.getAttribute("type");
+
+                    remapShadowType[name] = shadowType;
+                });
+
+            parser.parseFromString(get_block.xml, "text/xml")
+                .querySelectorAll(`[type="${get_block.json.type}"] > value`)
+                .forEach(el => {
+                    let name = el.getAttribute("name");
+                    if (!remapShadowType[name]) return;
+
+                    let shadowType = el.querySelector("shadow");
+                    if (!shadowType) return;
+                    shadowType = shadowType.getAttribute("type");
+
+                    if (remapShadowType[name] == shadowType) {
+                        delete remapShadowType[name];
+                        return;
+                    }
+                    remapShadowType[name] = shadowType;
+                });
+
+            return {
+                opcode: `${id}_${current.opcode}`,
+                msg: current.overwriteText ?? get_block.info.switchText ?? get_block.info.text,
+
+                mapFieldValues: current.remapMenus ?? {},
+                remapInputName: current.remapArguments ?? {},
+
+                createInputs,
+                splitInputs,
+                remapShadowType,
+            };
+        });
+    }
+    return _switches;
 }
 
 function getSwitches({runtime}) {
     var _switches = switches;
     for (let ext of runtime._blockInfo) {
         if (ext.id in _switches) continue;
-        _switches[ext.id] = {};
-        for (let block of ext.blocks) {
-            var blockswitches = block.info.switches;
-            if (!blockswitches) continue;
-            let opcode = block.info.opcode;
-            _switches[ext.id][opcode] = blockswitches.map(current => {
-                if (typeof current === "string") {
-                    current = {opcode: current}
-                } else if (typeof current !== "object") {
-                    return noopSwitch;
-                }
-
-                if ("isNoop" in current && current.isNoop) {
-                    return {
-                        isNoop: true,
-                        msg: current.overwriteText ?? block.info.switchText ?? block.info.text
-                    };
-                }
-
-                if (!("opcode" in current)) {
-                    return noopSwitch;
-                }
-
-                let get_block = ext.blocks.find(e => e.info.opcode === current.opcode);
-                if (!get_block) { // block doesn't exist.
-                    return noopSwitch;
-                }
-
-                let createInputs = {};
-                let currargs = current.createArguments ?? {};
-
-                const parser = new DOMParser();
-
-                parser.parseFromString(get_block.xml, "text/xml")
-                    .querySelectorAll(`[type="${get_block.json.type}"] > value`)
-                    .forEach(el => {
-                        let name = el.getAttribute("name");
-                        if (
-                            !!block.info.arguments[name]
-                            && !(current.remapArguments ?? {})[name]
-                        ) return;
-                        if (Object.values(current.remapArguments ?? {}).includes(name)) return;
-
-                        let shadowType = el.getElementsByTagName("shadow")[0].getAttribute("type");
-
-                        let value = (currargs[name] ?? get_block.info.arguments[name].defaultValue ?? "").toString();
-
-                        createInputs[name] = {
-                            shadowType,
-                            value
-                        };
-                    });
-
-                const splitInputs = Object.keys(block.info.arguments)
-                    .filter(arg => !Object.keys(get_block.info.arguments).includes(arg) && !Object.keys(current.remapArguments ?? {}).includes(arg));
-
-                const remapShadowType = {};
-
-                parser.parseFromString(block.xml, "text/xml")
-                    .querySelectorAll(`[type="${block.json.type}"] > value`)
-                    .forEach(el => {
-                        let name = el.getAttribute("name");
-                        if (!(name in get_block.info.arguments)) return;
-                        let shadowType = el.querySelector("shadow")
-                        if (!shadowType) return;
-                        shadowType = shadowType.getAttribute("type");
-                        remapShadowType[name] = shadowType;
-                    });
-
-                parser.parseFromString(get_block.xml, "text/xml")
-                    .querySelectorAll(`[type="${get_block.json.type}"] > value`)
-                    .forEach(el => {
-                        let name = el.getAttribute("name");
-                        if (!(name in remapShadowType)) return;
-
-                        let shadowType = el.querySelector("shadow");
-                        if (!shadowType) {
-                            return;
-                        }
-                        shadowType = shadowType.getAttribute("type");
-
-                        if (remapShadowType[name] == shadowType) {
-                            delete remapShadowType[name];
-                            return;
-                        }
-                        remapShadowType[name] = shadowType;
-                    });
-
-                return {
-                    opcode: `${ext.id}_${current.opcode}`,
-                    remapInputName: current.remapArguments ?? {},
-                    createInputs,
-                    splitInputs,
-                    remapShadowType,
-                    mapFieldValues: current.remapMenus ?? {},
-                    msg: current.overwriteText ?? get_block.info.switchText ?? get_block.info.text,
-                };
-            });
-        }
+        _switches[ext.id] = get_extension_switches(ext.id, ext.blocks);
     }
     return _switches;
 }
 
 module.exports = getSwitches;
+module.exports.get_extension_switches = get_extension_switches;
+module.exports.noopSwitch = { isNoop: true };

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -71,6 +71,7 @@ function get_extension_switches(id, blocks) {
                 .filter(arg =>
                     !!get_block.info.arguments[arg]
                     && !!(current.remapArguments ?? {})[arg]
+                    && !Object.values(current.remapArguments ?? {}).includes(arg)
                 );
 
             const remapShadowType = {};

--- a/src/extension-support/extension-addon-switchers.js
+++ b/src/extension-support/extension-addon-switchers.js
@@ -1,4 +1,4 @@
-const log = require('../util/log');
+const log = require("../util/log");
 const switches = {};
 const parser = new DOMParser();
 
@@ -124,12 +124,11 @@ function get_extension_switches(id, blocks) {
 }
 
 function getSwitches({runtime}) {
-    var _switches = switches;
     for (let ext of runtime._blockInfo) {
         if (ext.id in _switches) continue;
-        _switches[ext.id] = get_extension_switches(ext.id, ext.blocks);
+        switches[ext.id] = get_extension_switches(ext.id, ext.blocks);
     }
-    return _switches;
+    return switches;
 }
 
 module.exports = getSwitches;

--- a/src/extensions/jg_dev/index.js
+++ b/src/extensions/jg_dev/index.js
@@ -585,6 +585,25 @@ class JgDevBlocks {
                         noopSwitch,
                     ]
                 },
+                {
+                    opcode: "switches_broken",
+                    text: "intentionally broken switch",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            menu: "switch_menu2"
+                        }
+                    },
+                    switches: [
+                        {},
+                        [ "a" ],
+                        new Map(),
+                        17,
+                        -18,
+                        "switches_donotdefinemeangryfaceemoji",
+                    ]
+                },
             ],
             menus: {
                 variableInternal: {

--- a/src/extensions/jg_dev/index.js
+++ b/src/extensions/jg_dev/index.js
@@ -5,6 +5,7 @@ const ArgumentAlignment = require('../../extension-support/argument-alignment');
 const Cast = require('../../util/cast');
 const MathUtil = require('../../util/math-util');
 const test_indicator = require('./test_indicator.png');
+const { noopSwitch } = require('../../extension-support/extension-addon-switchers')
 
 const pathToMedia = 'static/blocks-media';
 
@@ -365,6 +366,225 @@ class JgDevBlocks {
                         }
                     }
                 },
+                {
+                    blockType: BlockType.LABEL,
+                    text: "switching test cases"
+                },
+                {
+                    opcode: "switches_noparams",
+                    text: "Switches test case 1",
+                    func: "noop",
+                    blockType: BlockType.COMMAND,
+                    switches: [
+                        noopSwitch,
+                        "switches_noparams2"
+                    ]
+                },
+                {
+                    opcode: "switches_noparams2",
+                    text: "Switches test case 2",
+                    func: "noop",
+                    blockType: BlockType.COMMAND,
+                    switches: [
+                        "switches_noparams",
+                        noopSwitch,
+                    ]
+                },
+                {
+                    opcode: "switches_params",
+                    text: "Has params [p1] [p2]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "hello"
+                        },
+                        p2: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "world"
+                        }
+                    },
+                    switches: [
+                        noopSwitch,
+                        "switches_params2"
+                    ]
+                },
+                {
+                    opcode: "switches_params2",
+                    text: "Has params2 [p1] [p2]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "hi"
+                        },
+                        p2: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "earth"
+                        }
+                    },
+                    switches: [
+                        "switches_params",
+                        noopSwitch,
+                    ]
+                },
+                {
+                    opcode: "switches_createparams",
+                    text: "Create params",
+                    func: "noop",
+                    blockType: BlockType.COMMAND,
+                    switches: [
+                        "switches_deleteparams",
+                        noopSwitch,
+                    ]
+                },
+                {
+                    opcode: "switches_deleteparams",
+                    text: "Delete params [p1] [p2]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "hello"
+                        },
+                        p2: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: "3"
+                        }
+                    },
+                    switches: [
+                        noopSwitch,
+                        "switches_createparams"
+                    ]
+                },
+                {
+                    opcode: "switches_renameparams",
+                    text: "Rename params [p1] [p2]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "hello"
+                        },
+                        p2: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: "3"
+                        }
+                    },
+                    switches: [
+                        noopSwitch,
+                        {
+                            opcode: "switches_renameparams2",
+                            remapArguments: {
+                                p1: "p3",
+                                p2: "p1"
+                            }
+                        }
+                    ]
+                },
+                {
+                    opcode: "switches_renameparams2",
+                    text: "Rename params2 [p3] [p1]",
+                    func: "noop",
+                    arguments: {
+                        p3: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "hi"
+                        },
+                        p1: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: "5"
+                        }
+                    },
+                    switches: [
+                        noopSwitch,
+                        {
+                            opcode: "switches_renameparams",
+                            remapArguments: {
+                                p3: "p1",
+                                p1: "p2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    opcode: "switches_shadow1",
+                    text: "Switch shadow type [p1]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "3"
+                        }
+                    },
+                    switches: [
+                        noopSwitch,
+                        "switches_shadow2"
+                    ]
+                },
+                {
+                    opcode: "switches_shadow2",
+                    text: "Switch shadow type2 [p1]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: "1"
+                        }
+                    },
+                    switches: [
+                        "switches_shadow1",
+                        noopSwitch,
+                    ]
+                },
+                {
+                    opcode: "switches_menu1",
+                    text: "Switch menus [p1]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            menu: "switch_menu1"
+                        }
+                    },
+                    switches: [
+                        noopSwitch,
+                        {
+                            opcode: "switches_menu2",
+                            remapMenus: {
+                                p1: {
+                                    "3": "1",
+                                    "2": "1",
+                                    "1": "0",
+                                    "0": "0",
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    opcode: "switches_menu2",
+                    text: "Switch menus2 [p1]",
+                    func: "noop",
+                    arguments: {
+                        p1: {
+                            type: ArgumentType.STRING,
+                            menu: "switch_menu2"
+                        }
+                    },
+                    switches: [
+                        {
+                            opcode: "switches_menu1",
+                            remapMenus: {
+                                p1: {
+                                    "1": "2",
+                                    "0": "1",
+                                }
+                            }
+                        },
+                        noopSwitch,
+                    ]
+                },
             ],
             menus: {
                 variableInternal: {
@@ -394,6 +614,20 @@ class JgDevBlocks {
                         { text: "BLOCK!!!", value: "block" },
                         { text: "Label Function ;D", value: "function" },
                     ]
+                },
+                switch_menu1: {
+                    items: [
+                        "aaaa!",
+                        "oh no",
+                        "why do i need this many",
+                        "an extra one IG."
+                    ].map((text, value) => { return { text, value: value.toString() } })
+                },
+                switch_menu2: {
+                    items: [
+                        "ok",
+                        "I only need a couple here."
+                    ].map((text, value) => { return { text, value: value.toString() } })
                 }
             }
         };
@@ -744,6 +978,11 @@ class JgDevBlocks {
     }
     givesAnError() {
         throw new Error('woah an error');
+    }
+
+    noop() {
+        // Generic noop
+        return;
     }
 }
 


### PR DESCRIPTION
* Refactor `get_extension_switches` into its own function and redo a bunch of booleans for speed.
* Export a little bit more for the purposes of testing and/or extensions.
* Add `isError` to error messages for the addon to potentially use at some point in the future.
* Fix to split inputs so it doesn't remove an essential element.
* Use new name to check if the shadowType should change rather than the old name.
* Adds some new blocks to `jg_dev` for testing the API.