### PR TITLE
Add new Block Shapes for JS Types using Custom Block Shape API (VM)

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1789,8 +1789,7 @@ class Runtime extends EventEmitter {
         else if (typeof blockShape === 'string') {
             // assume we are handling a custom shape...
             // if it doesnt exist it will default to a round reporter
-            if (blockShape.startsWith('native-')) blockJSON.outputShape = blockShape;
-            else if (!blockShape.startsWith('custom-')) blockJSON.outputShape = 'custom-' + blockShape;
+            if (!blockShape.startsWith('custom-')) blockJSON.outputShape = 'custom-' + blockShape;
             else blockJSON.outputShape = blockShape;
         }
         if (blockInfo.forceOutputType) {
@@ -1976,8 +1975,7 @@ class Runtime extends EventEmitter {
                 else {
                     // assume we are handling a custom shape...
                     // if it doesnt exist it will default to a null input
-                    if (argShape.startsWith('native-')) argJSON.shape = argShape;
-                    else if (!argShape.startsWith('custom-')) argJSON.shape = 'custom-' + argShape;
+                    if (!argShape.startsWith('custom-')) argJSON.shape = 'custom-' + argShape;
                     else argJSON.shape = argShape;
                 }
             }

--- a/src/extension-support/block-shape.js
+++ b/src/extension-support/block-shape.js
@@ -54,9 +54,9 @@ const BlockShape = {
     ARROW: 10,
 
     /**
-     * pm: Output shape: bookmark (Dates).
+     * pm: Output shape: ticket (Dates).
      */
-    BOOKMARK: 11,
+    TICKET: 11,
 };
 
 module.exports = BlockShape;

--- a/src/extension-support/block-shape.js
+++ b/src/extension-support/block-shape.js
@@ -19,14 +19,44 @@ const BlockShape = {
     SQUARE: 3,
 
     /**
-     * Output shape: leaf-ed (vectors).
+     * pm: Output shape: leaf-ed (vectors).
      */
     LEAF: 4,
 
     /**
-     * Output shape: plus (objects/classes or class instances).
+     * pm: Output shape: plus (objects/classes or class instances).
      */
     PLUS: 5,
+
+    /**
+     * pm: Output shape: octagonal (Scratch targets).
+     */
+    OCTAGONAL: 6,
+
+    /**
+     * pm: Output shape: bumped (BigInt).
+     */
+    BUMPED: 7,
+
+    /**
+     * pm: Output shape: indented (Symbols).
+     */
+    INDENTED: 8,
+
+    /**
+     * pm: Output shape: scrapped (Maps).
+     */
+    SCRAPPED: 9,
+
+    /**
+     * pm: Output shape: arrow (Sets).
+     */
+    ARROW: 10,
+
+    /**
+     * pm: Output shape: bookmark (Dates).
+     */
+    BOOKMARK: 11,
 };
 
 module.exports = BlockShape;

--- a/src/extensions/jg_dev/index.js
+++ b/src/extensions/jg_dev/index.js
@@ -431,10 +431,10 @@ class JgDevBlocks {
                     }
                 },
                 {
-                    opcode: 'customShapeBOOKMARK',
-                    text: 'custom shape BOOKMARK [TEST]',
-                    forceOutputType: BlockShape.BOOKMARK,
-                    blockShape: BlockShape.BOOKMARK,
+                    opcode: 'customShapeTICKET',
+                    text: 'custom shape TICKET [TEST]',
+                    forceOutputType: BlockShape.TICKET,
+                    blockShape: BlockShape.TICKET,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         TEST: {
@@ -498,11 +498,11 @@ class JgDevBlocks {
                     blockType: BlockType.REPORTER,
                 },
                 {
-                    opcode: 'customShapeInputBOOKMARK',
+                    opcode: 'customShapeInputTICKET',
                     arguments: {
                         TEST: {
-                            shape: BlockShape.BOOKMARK,
-                            check: BlockShape.BOOKMARK,
+                            shape: BlockShape.TICKET,
+                            check: BlockShape.TICKET,
                         }
                     },
                     text: 'custom shape [TEST]',

--- a/src/extensions/jg_dev/index.js
+++ b/src/extensions/jg_dev/index.js
@@ -385,6 +385,7 @@ class JgDevBlocks {
                 {
                     opcode: 'customShapeBUMPED',
                     text: 'custom shape BUMPED [TEST]',
+                    forceOutputType: BlockShape.BUMPED,
                     blockShape: BlockShape.BUMPED,
                     blockType: BlockType.REPORTER,
                     arguments: {
@@ -396,6 +397,7 @@ class JgDevBlocks {
                 {
                     opcode: 'customShapeINDENTED',
                     text: 'custom shape INDENTED [TEST]',
+                    forceOutputType: BlockShape.INDENTED,
                     blockShape: BlockShape.INDENTED,
                     blockType: BlockType.REPORTER,
                     arguments: {
@@ -407,6 +409,7 @@ class JgDevBlocks {
                 {
                     opcode: 'customShapeSCRAPPED',
                     text: 'custom shape SCRAPPED [TEST]',
+                    forceOutputType: BlockShape.SCRAPPED,
                     blockShape: BlockShape.SCRAPPED,
                     blockType: BlockType.REPORTER,
                     arguments: {
@@ -418,6 +421,7 @@ class JgDevBlocks {
                 {
                     opcode: 'customShapeARROW',
                     text: 'custom shape ARROW [TEST]',
+                    forceOutputType: BlockShape.ARROW,
                     blockShape: BlockShape.ARROW,
                     blockType: BlockType.REPORTER,
                     arguments: {
@@ -429,6 +433,7 @@ class JgDevBlocks {
                 {
                     opcode: 'customShapeBOOKMARK',
                     text: 'custom shape BOOKMARK [TEST]',
+                    forceOutputType: BlockShape.BOOKMARK,
                     blockShape: BlockShape.BOOKMARK,
                     blockType: BlockType.REPORTER,
                     arguments: {

--- a/src/extensions/jg_dev/index.js
+++ b/src/extensions/jg_dev/index.js
@@ -368,6 +368,143 @@ class JgDevBlocks {
                 },
                 {
                     blockType: BlockType.LABEL,
+                    text: "Native CUSTOM_SHAPES"
+                },
+                {
+                    opcode: 'customShapeOCTAGONAL',
+                    text: 'custom shape OCTAGONAL [TEST]',
+                    forceOutputType: BlockShape.OCTAGONAL,
+                    blockShape: BlockShape.OCTAGONAL,
+                    blockType: BlockType.REPORTER,
+                    arguments: {
+                        TEST: {
+                            type: ArgumentType.STRING,
+                        }
+                    }
+                },
+                {
+                    opcode: 'customShapeBUMPED',
+                    text: 'custom shape BUMPED [TEST]',
+                    blockShape: BlockShape.BUMPED,
+                    blockType: BlockType.REPORTER,
+                    arguments: {
+                        TEST: {
+                            type: ArgumentType.STRING,
+                        }
+                    }
+                },
+                {
+                    opcode: 'customShapeINDENTED',
+                    text: 'custom shape INDENTED [TEST]',
+                    blockShape: BlockShape.INDENTED,
+                    blockType: BlockType.REPORTER,
+                    arguments: {
+                        TEST: {
+                            type: ArgumentType.STRING,
+                        }
+                    }
+                },
+                {
+                    opcode: 'customShapeSCRAPPED',
+                    text: 'custom shape SCRAPPED [TEST]',
+                    blockShape: BlockShape.SCRAPPED,
+                    blockType: BlockType.REPORTER,
+                    arguments: {
+                        TEST: {
+                            type: ArgumentType.STRING,
+                        }
+                    }
+                },
+                {
+                    opcode: 'customShapeARROW',
+                    text: 'custom shape ARROW [TEST]',
+                    blockShape: BlockShape.ARROW,
+                    blockType: BlockType.REPORTER,
+                    arguments: {
+                        TEST: {
+                            type: ArgumentType.STRING,
+                        }
+                    }
+                },
+                {
+                    opcode: 'customShapeBOOKMARK',
+                    text: 'custom shape BOOKMARK [TEST]',
+                    blockShape: BlockShape.BOOKMARK,
+                    blockType: BlockType.REPORTER,
+                    arguments: {
+                        TEST: {
+                            type: ArgumentType.STRING,
+                        }
+                    }
+                },
+                {
+                    opcode: 'customShapeInputOCTAGONAL',
+                    arguments: {
+                        TEST: {
+                            shape: BlockShape.OCTAGONAL,
+                            check: BlockShape.OCTAGONAL,
+                        }
+                    },
+                    text: 'custom shape [TEST]',
+                    blockType: BlockType.REPORTER,
+                },
+                {
+                    opcode: 'customShapeInputBUMPED',
+                    arguments: {
+                        TEST: {
+                            shape: BlockShape.BUMPED,
+                            check: BlockShape.BUMPED,
+                        }
+                    },
+                    text: 'custom shape [TEST]',
+                    blockType: BlockType.REPORTER,
+                },
+                {
+                    opcode: 'customShapeInputINDENTED',
+                    arguments: {
+                        TEST: {
+                            shape: BlockShape.INDENTED,
+                            check: BlockShape.INDENTED,
+                        }
+                    },
+                    text: 'custom shape [TEST]',
+                    blockType: BlockType.REPORTER,
+                },
+                {
+                    opcode: 'customShapeInputSCRAPPED',
+                    arguments: {
+                        TEST: {
+                            shape: BlockShape.SCRAPPED,
+                            check: BlockShape.SCRAPPED,
+                        }
+                    },
+                    text: 'custom shape [TEST]',
+                    blockType: BlockType.REPORTER,
+                },
+                {
+                    opcode: 'customShapeInputARROW',
+                    arguments: {
+                        TEST: {
+                            shape: BlockShape.ARROW,
+                            check: BlockShape.ARROW,
+                        }
+                    },
+                    text: 'custom shape [TEST]',
+                    blockType: BlockType.REPORTER,
+                },
+                {
+                    opcode: 'customShapeInputBOOKMARK',
+                    arguments: {
+                        TEST: {
+                            shape: BlockShape.BOOKMARK,
+                            check: BlockShape.BOOKMARK,
+                        }
+                    },
+                    text: 'custom shape [TEST]',
+                    blockType: BlockType.REPORTER,
+                },
+                {
+                    blockType: BlockType.LABEL,
                     text: "switching test cases"
                 },
                 {


### PR DESCRIPTION
Related:
https://github.com/PenguinMod/PenguinMod-Blocks/pull/28
https://github.com/PenguinMod/PenguinMod-Docs/pull/10