### PR TITLE
Make targets octagonal to match the new blockShapes with specific purposes.

### DIFF
--- a/src/extensions/jwTargets/index.js
+++ b/src/extensions/jwTargets/index.js
@@ -83,11 +83,13 @@ const Target = {
     Type: jwTargetType,
     Block: {
         blockType: BlockType.REPORTER,
+        blockShape: BlockShape.OCTAGONAL,
         forceOutputType: "Target",
         disableMonitor: true
     },
     Argument: {
-        check: ["Target"]
+        check: ["Target"],
+        shape: BlockShape.OCTAGONAL
     }
 }
 


### PR DESCRIPTION
puhleeasee
<img width="517" height="100" alt="image" src="https://github.com/user-attachments/assets/63b7ea21-b18e-4496-a50a-a27fafd9d4ba" />
