### PR TITLE
jwArrayHandler and dogeiscutObjectHandler now work for both strings and HTML

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-    extends: ['scratch', 'scratch/node', 'scratch/es6']
+    extends: ['scratch', 'scratch/node', 'scratch/es6'],
+    rules: {
+        'no-trailing-spaces': 'off'
+    }
 };

--- a/src/extension-support/custom-autoloaded-extensions.json
+++ b/src/extension-support/custom-autoloaded-extensions.json
@@ -1,0 +1,3 @@
+[
+    "http://localhost:5173/extensions/classes.js"
+]

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -256,9 +256,9 @@ const CORE_EXTENSIONS = [
 const coreExtensionList = Object.getOwnPropertyNames(defaultBuiltinExtensions);
 
 const preload = [];
-
-if (IsLocal || IsLiveTests) {
-    preload.push("jgDev");
+const customAutoloadedExtensions = require('./custom-autoloaded-extensions.json');
+if ((IsLocal || IsLiveTests)) {
+    preload.push('jgDev');
 }
 
 /**
@@ -363,6 +363,9 @@ class ExtensionManager {
             log.error(`ExtensionManager was unable to register extension service: ${JSON.stringify(e)}`);
         });
 
+        customAutoloadedExtensions.forEach(extensionId => {
+            this.loadExtensionURL(value);
+        })
         preload.forEach(value => {
             this.loadExtensionURL(value);
         });

--- a/src/extensions/jwArray/index.js
+++ b/src/extensions/jwArray/index.js
@@ -98,7 +98,7 @@ class ArrayType {
                 case "object":
                     if (x === null) return "null"
                     if (typeof x.jwArrayHandler == "function") {
-                        return x.jwArrayHandler()
+                        return x.jwArrayHandler(false, "array")
                     }
                     return "Object"
                 case "undefined":
@@ -114,7 +114,7 @@ class ArrayType {
         return "?"
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
         return `Array<${formatNumber(this.array.length)}>`
     }
 

--- a/src/extensions/jwColor/index.js
+++ b/src/extensions/jwColor/index.js
@@ -89,7 +89,9 @@ class ColorType {
         return this.fromRGB(r, g, b)
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
+        if (expectsPlainString) return this.toString()
+        
         let color = document.createElement('div')
         color.style.width = "16px"
         color.style.height = "16px"

--- a/src/extensions/jwDate/index.js
+++ b/src/extensions/jwDate/index.js
@@ -30,7 +30,7 @@ class DateType {
         return new DateType()
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
         return this.date.toLocaleDateString()
     }
 

--- a/src/extensions/jwLambda/index.js
+++ b/src/extensions/jwLambda/index.js
@@ -47,7 +47,7 @@ class LambdaType {
         return new LambdaType()
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
         return 'Lambda'
     }
 

--- a/src/extensions/jwNum/index.js
+++ b/src/extensions/jwNum/index.js
@@ -33,7 +33,7 @@ class NumType {
         return new NumType(x)
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
         return this.number.toStringWithDecimalPlaces(3)
     }
 

--- a/src/extensions/jwTargets/index.js
+++ b/src/extensions/jwTargets/index.js
@@ -39,7 +39,8 @@ class jwTargetType {
         return new jwTargetType("")
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
+        // always a string
         try {
             return escapeHTML(`Target<${this.target.sprite.name}>`)
         } catch {

--- a/src/extensions/jwVector/index.js
+++ b/src/extensions/jwVector/index.js
@@ -42,7 +42,7 @@ class VectorType {
         return new VectorType(0, 0)
     }
 
-    jwArrayHandler() {
+    jwArrayHandler(expectsPlainString, context) {
         return 'Vector'
     }
 

--- a/src/extensions/jwXML/index.js
+++ b/src/extensions/jwXML/index.js
@@ -117,8 +117,8 @@ class XMLType {
         ].reduce((a, b) => a.replaceAll(b, ""), text)
     }
 
-    jwArrayHandler() {
-        return XMLType.safeText(`<${this.name} />`)
+    jwArrayHandler(expectsPlainString, context) {
+        return XMLType.safeText(`<${this.name} />`) // always a string
     }
 
     toString(pretty = false, depth = 0) {


### PR DESCRIPTION
### Resolves

`dogeiscutObjectHandler` is used to represent items of an object.(`jwArrayHandler` is the same for arrays) It is used both for conversion `toString` and to HTML element. This is problematic as the object item e.g. can't know if it needs escape a string or if it can use html elements or not.
![](https://github.com/user-attachments/assets/3f9c63ca-e622-4c3c-9dfe-392ad634973c)

### Proposed Changes

I tried another solution but it was rightfully rejected: [PR 411](https://github.com/PenguinMod/PenguinMod-ExtensionsGallery/pull/411).

Add arguments to these handlers that specify expected return type and environment context(e.g. for a string, array representation or object representation).

### Important
As PM extensions are split between `PenguinMod-Vm` and `PenguinMod-ExtensionsGallery`, I had two create two seperate pull requests:
this one and [PR](https://github.com/PenguinMod/PenguinMod-ExtensionsGallery/pull/412)
