### PR TITLE
Placeholders: allow drop anywhere and disable auto casting

### DIFF
--- a/src/extensions/jw_proto/index.js
+++ b/src/extensions/jw_proto/index.js
@@ -71,7 +71,6 @@ class jwProto {
                         description: 'Label for labeling.'
                     }),
                     disableMonitor: true,
-                    exemptFromNormalization: true,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         LABEL: {
@@ -96,9 +95,7 @@ class jwProto {
                             type: ArgumentType.STRING,
                             defaultValue: "label"
                         },
-                        VALUE: {
-                            defaultValue: "value"
-                        }
+                        VALUE: {}
                     }
                 },
                 {

--- a/src/extensions/jw_proto/index.js
+++ b/src/extensions/jw_proto/index.js
@@ -71,6 +71,7 @@ class jwProto {
                         description: 'Label for labeling.'
                     }),
                     disableMonitor: true,
+                    exemptFromNormalization: true,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         LABEL: {
@@ -87,14 +88,15 @@ class jwProto {
                         description: 'Label for a value.'
                     }),
                     disableMonitor: true,
+                    exemptFromNormalization: true,
                     blockType: BlockType.REPORTER,
+                    allowDropAnywhere: true,
                     arguments: {
                         LABEL: {
                             type: ArgumentType.STRING,
                             defaultValue: "label"
                         },
                         VALUE: {
-                            type: ArgumentType.STRING,
                             defaultValue: "value"
                         }
                     }

--- a/src/extensions/jw_proto/index.js
+++ b/src/extensions/jw_proto/index.js
@@ -95,7 +95,10 @@ class jwProto {
                             type: ArgumentType.STRING,
                             defaultValue: "label"
                         },
-                        VALUE: {}
+                        VALUE: {
+                            type: ArgumentType.STRING,
+                            defaultValue: "value"
+                        }
                     }
                 },
                 {


### PR DESCRIPTION
This is untested but it's a small change, so I'd be surprised if it broke anything.