### PR TITLE
Add currently playing sounds

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -160,7 +160,8 @@ class Scratch3SoundBlocks {
             sound_set_stop_fadeout_to: this.setStopFadeout,
             sound_play_at_seconds: this.playAtSeconds,
             sound_play_at_seconds_until_done: this.playAtSecondsAndWait,
-            sound_getSoundVolume: this.currentSoundVolume
+            sound_getSoundVolume: this.currentSoundVolume,
+            sound_currentlyPlayingSounds: this.playingSounds,
         };
     }
 
@@ -174,11 +175,15 @@ class Scratch3SoundBlocks {
                 isSpriteSpecific: true,
                 getId: (targetId, fields) => getMonitorIdForBlockWithArgs(`${targetId}_soundgetEffectValue`, fields)
             },
+            sound_currentlyPlayingSounds: {
+                isSpriteSpecific: true,
+                getId: targetId => `${targetId}_currentlyPlayingSounds`
+            }
         };
     }
 
     currentSoundVolume (args, util) {
-        
+
     }
 
     playAtSeconds (args, util) {
@@ -186,7 +191,7 @@ class Scratch3SoundBlocks {
         if (seconds < 0) {
             return;
         }
-        
+
         this._playSoundAtTimePosition({
             sound: Cast.toString(args.SOUND_MENU),
             seconds: seconds
@@ -306,7 +311,7 @@ class Scratch3SoundBlocks {
         const target = util.target;
         const sprite = target.sprite;
         if (!sprite) return;
-        
+
         const { soundId } = sprite.sounds[index];
 
         const soundBank = sprite.soundBank
@@ -531,6 +536,21 @@ class Scratch3SoundBlocks {
 
     effectsMenu (args) {
         return args.EFFECT;
+    }
+
+    playingSounds(args, util) {
+        const sprite = util.target.sprite;
+        return JSON.stringify(
+            Object.entries(sprite.soundBank.soundPlayers)
+                .filter(
+                    ([_, player]) =>
+                        player.isPlaying
+                )
+                .map(
+                    ([key, _]) =>
+                        sprite.sounds.find(({soundId}) => soundId === key).name
+                )
+        );
     }
 }
 

--- a/src/compiler/compat-blocks.js
+++ b/src/compiler/compat-blocks.js
@@ -161,7 +161,8 @@ const outputBlocks = [
     'operator_xnor',
     'looks_getinputofcostume',
     'sound_getTimePosition',
-    'sound_getSoundVolume'
+    'sound_getSoundVolume',
+    'sound_currentlyPlayingSounds',
 ];
 
 module.exports = {


### PR DESCRIPTION
Resolves https://github.com/PenguinMod/PenguinMod-Home/issues/471

The adds a new block to the sound category which lists out all sounds which are currently playing. Primary point of this PR is that this block looked really easy to implement, so I implemented it.

It just outputs a JSON array because there's enough extensions specifically made to parse those that it should be fairly easy to handle.

## Related

* https://github.com/PenguinMod/penguinmod.github.io/pull/186
* https://github.com/PenguinMod/PenguinMod-Blocks/pull/42