### PR TITLE
Allow extensions to access sequencer active thread iterator

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1169,16 +1169,16 @@ class Runtime extends EventEmitter {
      * Event name for before the sequencer executes a tick.
      * @const {string}
      */
-    static get TICK_STARTED () {
-        return 'TICK_STARTED'
+    static get BEFORE_TICK () {
+        return 'BEFORE_TICK'
     }
 
     /**
      * Event name for after the sequencer executes a tick.
      * @const {string}
      */
-    static get TICK_FINISHED () {
-        return 'TICK_FINISHED'
+    static get AFTER_TICK () {
+        return 'AFTER_TICK'
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1166,6 +1166,22 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for before the sequencer executes a tick.
+     * @const {string}
+     */
+    static get TICK_STARTED () {
+        return 'TICK_STARTED'
+    }
+
+    /**
+     * Event name for after the sequencer executes a tick.
+     * @const {string}
+     */
+    static get TICK_FINISHED () {
+        return 'TICK_FINISHED'
+    }
+
+    /**
      * Event name for sprite renaming.
      * @const {string}
      */

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1166,22 +1166,6 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Event name for before the sequencer executes a tick.
-     * @const {string}
-     */
-    static get BEFORE_TICK () {
-        return 'BEFORE_TICK'
-    }
-
-    /**
-     * Event name for after the sequencer executes a tick.
-     * @const {string}
-     */
-    static get AFTER_TICK () {
-        return 'AFTER_TICK'
-    }
-
-    /**
      * Event name for sprite renaming.
      * @const {string}
      */

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -102,7 +102,6 @@ class Sequencer {
             let stoppedThread = false;
             // Attempt to run each thread one time.
             const threads = this.runtime.threads;
-            this.runtime.emit('BEFORE_TICK', threads);
             for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++) {
                 const i = this.activeThreadIndex;
                 // Check if the thread is done so it is not executed.
@@ -148,7 +147,6 @@ class Sequencer {
                     stoppedThread = true;
                 }
             }
-            this.runtime.emit('AFTER_TICK', threads);
             // We successfully ticked once. Prevents running STATUS_YIELD_TICK
             // threads on the next tick.
             ranFirstTick = true;

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -102,7 +102,7 @@ class Sequencer {
             let stoppedThread = false;
             // Attempt to run each thread one time.
             const threads = this.runtime.threads;
-            this.runtime.emit('TICK_STARTED', threads);
+            this.runtime.emit('BEFORE_TICK', threads);
             for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++) {
                 const i = this.activeThreadIndex;
                 // Check if the thread is done so it is not executed.
@@ -148,7 +148,7 @@ class Sequencer {
                     stoppedThread = true;
                 }
             }
-            this.runtime.emit('TICK_FINISHED', threads);
+            this.runtime.emit('AFTER_TICK', threads);
             // We successfully ticked once. Prevents running STATUS_YIELD_TICK
             // threads on the next tick.
             ranFirstTick = true;

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -53,6 +53,7 @@ class Sequencer {
          */
         this.runtime = runtime;
 
+        this.activeThreadIndex = null;
         this.activeThread = null;
     }
 
@@ -101,8 +102,9 @@ class Sequencer {
             let stoppedThread = false;
             // Attempt to run each thread one time.
             const threads = this.runtime.threads;
-            for (let i = 0; i < threads.length; i++) {
-                const activeThread = this.activeThread = threads[i];
+            this.runtime.emit('TICK_STARTED', threads);
+            for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++) {
+                const i = this.activeThreadIndex;
                 // Check if the thread is done so it is not executed.
                 if (activeThread.stack.length === 0 ||
                     activeThread.status === Thread.STATUS_DONE) {
@@ -146,6 +148,7 @@ class Sequencer {
                     stoppedThread = true;
                 }
             }
+            this.runtime.emit('TICK_FINISHED', threads);
             // We successfully ticked once. Prevents running STATUS_YIELD_TICK
             // threads on the next tick.
             ranFirstTick = true;


### PR DESCRIPTION
### Resolves

#172

### Proposed Changes

Makes the iterator of this loop writable via `sequencer.activeThreadIndex`: https://github.com/the-can-of-soup/PenguinMod-Vm/blob/18681e4a45dba9f779d6b2a4e0fc4cc72593ec35/src/engine/sequencer.js#L105-L151

Also adds `BEFORE_TICK` and `AFTER_TICK` events.
**EDIT:** I removed these because @SharkPool-SP said to.

### Reason for Changes

This makes it easier for [my extension](https://github.com/the-can-of-soup/pm_threads) and other extensions to interact with the sequencer at runtime.

### Test Coverage

> _Please show how you have added tests to cover your changes_

I didn't lol
