### PR TITLE
Add events for before and after tick

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1182,6 +1182,22 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for before the sequencer steps a thread.
+     * @const {string}
+     */
+    static get BEFORE_STEP () {
+        return 'BEFORE_STEP'
+    }
+
+    /**
+     * Event name for after the sequencer steps a thread.
+     * @const {string}
+     */
+    static get AFTER_STEP () {
+        return 'AFTER_STEP'
+    }
+
+    /**
      * Event name for sprite renaming.
      * @const {string}
      */

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1166,6 +1166,22 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for before the sequencer executes a tick.
+     * @const {string}
+     */
+    static get BEFORE_TICK () {
+        return 'BEFORE_TICK'
+    }
+
+    /**
+     * Event name for after the sequencer executes a tick.
+     * @const {string}
+     */
+    static get AFTER_TICK () {
+        return 'AFTER_TICK'
+    }
+
+    /**
      * Event name for sprite renaming.
      * @const {string}
      */

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1182,6 +1182,22 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for before the sequencer considers a thread to be stepped.
+     * @const {string}
+     */
+    static get BEFORE_THREAD_CONSIDERED () {
+        return 'BEFORE_THREAD_CONSIDERED'
+    }
+
+    /**
+     * Event name for after the sequencer considers a thread to be stepped.
+     * @const {string}
+     */
+    static get AFTER_THREAD_CONSIDERED () {
+        return 'AFTER_THREAD_CONSIDERED'
+    }
+
+    /**
      * Event name for before the sequencer steps a thread.
      * @const {string}
      */

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1185,16 +1185,16 @@ class Runtime extends EventEmitter {
      * Event name for before the sequencer steps a thread.
      * @const {string}
      */
-    static get BEFORE_STEP () {
-        return 'BEFORE_STEP'
+    static get BEFORE_THREAD_STEP () {
+        return 'BEFORE_THREAD_STEP'
     }
 
     /**
      * Event name for after the sequencer steps a thread.
      * @const {string}
      */
-    static get AFTER_STEP () {
-        return 'AFTER_STEP'
+    static get AFTER_THREAD_STEP () {
+        return 'AFTER_THREAD_STEP'
     }
 
     /**

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -104,10 +104,10 @@ class Sequencer {
             const threads = this.runtime.threads;
             this.runtime.emit('BEFORE_TICK', threads);
             for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++,
-                 this.runtime.emit('AFTER_THREAD_STEP', this.activeThread)) {
+                 this.runtime.emit('AFTER_THREAD_CONSIDERED', this.activeThread)) {
                 const i = this.activeThreadIndex;
                 const activeThread = this.activeThread = threads[i];
-                this.runtime.emit('BEFORE_THREAD_STEP', activeThread);
+                this.runtime.emit('BEFORE_THREAD_CONSIDERED', activeThread);
                 // Check if the thread is done so it is not executed.
                 if (activeThread.stack.length === 0 ||
                     activeThread.status === Thread.STATUS_DONE) {
@@ -189,8 +189,11 @@ class Sequencer {
      * @param {!Thread} thread Thread object to step.
      */
     stepThread (thread) {
+        this.runtime.emit('BEFORE_THREAD_STEP', thread);
+        
         if (thread.isCompiled) {
             compilerExecute(thread);
+            this.runtime.emit('AFTER_THREAD_STEP', thread);
             return;
         }
 
@@ -203,6 +206,7 @@ class Sequencer {
             if (thread.stack.length === 0) {
                 thread.status = Thread.STATUS_DONE;
                 this.runtime.emit('THREAD_FINISHED', thread);
+                this.runtime.emit('AFTER_THREAD_STEP', thread);
                 return;
             }
         }
@@ -244,12 +248,15 @@ class Sequencer {
                 // A promise was returned by the primitive. Yield the thread
                 // until the promise resolves. Promise resolution should reset
                 // thread.status to Thread.STATUS_RUNNING.
+                this.runtime.emit('AFTER_THREAD_STEP', thread);
                 return;
             } else if (thread.status === Thread.STATUS_YIELD_TICK) {
                 // stepThreads will reset the thread to Thread.STATUS_RUNNING
+                this.runtime.emit('AFTER_THREAD_STEP', thread);
                 return;
             } else if (thread.status === Thread.STATUS_DONE) {
                 // Nothing more to execute.
+                this.runtime.emit('AFTER_THREAD_STEP', thread);
                 return;
             }
             // If no control flow has happened, switch to next block.
@@ -264,6 +271,7 @@ class Sequencer {
                     // No more stack to run!
                     thread.status = Thread.STATUS_DONE;
                     this.runtime.emit('THREAD_FINISHED', thread);
+                    this.runtime.emit('AFTER_THREAD_STEP', thread);
                     return;
                 }
 
@@ -279,22 +287,27 @@ class Sequencer {
                         thread.warpTimer.timeElapsed() > Sequencer.WARP_TIME) {
                         // Don't do anything to the stack, since loops need
                         // to be re-executed.
+                        this.runtime.emit('AFTER_THREAD_STEP', thread);
                         return;
                     }
                     // Don't go to the next block for this level of the stack,
                     // since loops need to be re-executed.
+                    this.runtime.emit('AFTER_THREAD_STEP', thread);
                     continue;
 
                 } else if (stackFrame.waitingReporter) {
                     // This level of the stack was waiting for a value.
                     // This means a reporter has just returned - so don't go
                     // to the next block for this level of the stack.
+                    this.runtime.emit('AFTER_THREAD_STEP', thread);
                     return;
                 }
                 // Get next block of existing block on the stack.
                 thread.goToNextBlock();
             }
         }
+
+        this.runtime.emit('AFTER_THREAD_STEP', thread);
     }
 
     /**

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -103,9 +103,11 @@ class Sequencer {
             // Attempt to run each thread one time.
             const threads = this.runtime.threads;
             this.runtime.emit('BEFORE_TICK', threads);
-            for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++) {
+            for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++,
+                 this.runtime.emit('AFTER_STEP', this.activeThread)) {
                 const i = this.activeThreadIndex;
                 const activeThread = this.activeThread = threads[i];
+                this.runtime.emit('BEFORE_STEP', activeThread);
                 // Check if the thread is done so it is not executed.
                 if (activeThread.stack.length === 0 ||
                     activeThread.status === Thread.STATUS_DONE) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -177,6 +177,7 @@ class Sequencer {
         }
 
         this.activeThread = null;
+        this.activeThreadIndex = null;
 
         return doneThreads;
     }

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -104,10 +104,10 @@ class Sequencer {
             const threads = this.runtime.threads;
             this.runtime.emit('BEFORE_TICK', threads);
             for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++,
-                 this.runtime.emit('AFTER_STEP', this.activeThread)) {
+                 this.runtime.emit('AFTER_THREAD_STEP', this.activeThread)) {
                 const i = this.activeThreadIndex;
                 const activeThread = this.activeThread = threads[i];
-                this.runtime.emit('BEFORE_STEP', activeThread);
+                this.runtime.emit('BEFORE_THREAD_STEP', activeThread);
                 // Check if the thread is done so it is not executed.
                 if (activeThread.stack.length === 0 ||
                     activeThread.status === Thread.STATUS_DONE) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -102,6 +102,7 @@ class Sequencer {
             let stoppedThread = false;
             // Attempt to run each thread one time.
             const threads = this.runtime.threads;
+            this.runtime.emit('BEFORE_TICK', threads);
             for (this.activeThreadIndex = 0; this.activeThreadIndex < threads.length; this.activeThreadIndex++) {
                 const i = this.activeThreadIndex;
                 const activeThread = this.activeThread = threads[i];
@@ -148,6 +149,7 @@ class Sequencer {
                     stoppedThread = true;
                 }
             }
+            this.runtime.emit('AFTER_TICK', threads);
             // We successfully ticked once. Prevents running STATUS_YIELD_TICK
             // threads on the next tick.
             ranFirstTick = true;


### PR DESCRIPTION
### Resolves

#174

### Proposed Changes

This PR adds `BEFORE_TICK` and `AFTER_TICK` events which run before and after every thread is stepped once.
**Edit:** Also added `BEFORE_STEP` and `AFTER_STEP`.
**Edit 2:** Renamed to `BEFORE_THREAD_STEP` and `AFTER_THREAD_STEP`.
**Edit 3:** Also added `BEFORE_THREAD_CONSIDERED` and `AFTER_THREAD_CONSIDERED`.

Unlike `BEFORE_EXECUTE` and `AFTER_EXECUTE`, these are wrapped around the *tick*, not the *frame*.

### Reason for Changes

This makes it easier for [my extension](https://github.com/the-can-of-soup/pm_threads) and other extensions to interact with the sequencer at runtime.

### Test Coverage

> _Please show how you have added tests to cover your changes_

I didn't lol
