### PR TITLE
Implement mobile debugging support with Eruda

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -74,6 +74,11 @@ class VirtualMachine extends EventEmitter {
     constructor () {
         super();
 
+			  /**
+				 * allows mobile debugging as browsers in mobile lack dev tools
+				 */
+			  this.enableEruda = function () { var script = document.createElement('script'); script.src="https://cdn.jsdelivr.net/npm/eruda"; document.body.append(script); script.onload = function () { eruda.init(); } };
+
         /**
          * VM runtime, to store blocks, I/O devices, sprites/targets, etc.
          * @type {!Runtime}


### PR DESCRIPTION
Add method to enable mobile debugging with Eruda.

### Proposed Changes

It resolves the issue of mobile extension development being more limited because it lacks dev tools by adding a development function in `Scratch` called `enableEruda` which adds [eruda](https://eruda.liriliri.io) in the website which is a replacement of dev tools provided by the browser in computers

### Reason for Changes

Because as said above, it allows testing extensions in mobile to the max because it gives a dev tool alternative that isn't exclusively available on computers as it's provided through a HTML script

### Test Covera

I didn't add test in the repo but if you add
```js
Scratch.enableEruda = function () { var script = document.createElement('script'); script.src="https://cdn.jsdelivr.net/npm/eruda"; document.body.append(script); script.onload = function () { eruda.init(); } };
```
On top (very top but inside) of the self invoking function or above (outside) it then run the function in the self invoking function then you will see it works
