### PR TITLE
Disable unnecessary warning for empty null inputs

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -156,7 +156,7 @@ class ScriptTreeGenerator {
     descendInputOfBlock (parentBlock, inputName) {
         const input = parentBlock.inputs[inputName];
         if (!input) {
-            log.warn(`IR: ${parentBlock.opcode}: missing input ${inputName}`, parentBlock);
+            // log.warn(`IR: ${parentBlock.opcode}: missing input ${inputName}`, parentBlock);
             return {
                 kind: 'constant',
                 value: null


### PR DESCRIPTION
### Resolves

im not making an issue for ts

### Proposed Changes

Read the title.

### Reason for Changes

Many extensions (and even some built-in blocks) use null inputs and it seems unnecessary to warn whenever they are compiled with empty slots.

### Test Coverage

i didnt lol
