### PR TITLE
Refactor toMonitorContent method syntax in jwArray

### DIFF
--- a/src/extensions/jwArray/index.js
+++ b/src/extensions/jwArray/index.js
@@ -133,7 +133,7 @@ class ArrayType {
         })
     }
 
-    toMonitorContent = () => span(this.toString())
+    toMonitorContent() { return span(this.toString()) }
 
     toReporterContent() {
         let root = document.createElement('div')

--- a/src/extensions/jwArray/index.js
+++ b/src/extensions/jwArray/index.js
@@ -133,7 +133,9 @@ class ArrayType {
         })
     }
 
-    toMonitorContent() { return span(this.toString()) }
+    toMonitorContent() {
+        return span(this.toString());
+    }
 
     toReporterContent() {
         let root = document.createElement('div')


### PR DESCRIPTION
`toMonitorContent` shows up/is remade in `ArrayType` instances, breaks `super.toMonitorContent()` in subclasses, and is unpatchable. 

Changing it to use method syntax fixes all of these problems.

### Proposed Changes

changes `toMonitorContent ` in jwArray from an arrow function being assigned to a property, to an actual method definition.

### Reason for Changes

i neeeeeeeeeed to patch `toMonitorContent` for something in the objects rewrite 

### Test Coverage

it's a really basic syntax change. if this breaks anything somehow then you can ban me from ever making code changes again.
