### PR TITLE
Fix lambdas executing procedures with the wrong thread

### DIFF
--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -215,6 +215,7 @@ class Thread {
          * @type {Object.<string, !CompiledScript>}
          */
         this.procedures = null;
+        this.procedureFactories = null;
         this.executableHat = false;
         this.compatibilityStackFrame = null;
 
@@ -556,8 +557,10 @@ class Thread {
         }
 
         this.procedures = {};
+        this.procedureFactories = {};
         for (const procedureCode of Object.keys(result.procedures)) {
-            this.procedures[procedureCode] = result.procedures[procedureCode](this);
+            this.procedureFactories[procedureCode] = result.procedures[procedureCode];
+            this.procedures[procedureCode] = this.procedureFactories[procedureCode](this);
         }
         
         this.generator = result.startingFunction(this)();

--- a/src/extensions/jwLambda/index.js
+++ b/src/extensions/jwLambda/index.js
@@ -38,7 +38,7 @@ class LambdaType {
 
     constructor(func = function*() {}, thread) {
         this.func = func
-        this.proc = thread ? thread.procedures : {}
+        this.procedureFactories = thread ? thread.procedureFactories : {}
         this.timesExecuted = 0
     }
 
@@ -67,7 +67,15 @@ class LambdaType {
     execute = function* (arg, thread, target, runtime, stage) {
         thread._jwLambdaArgument ??= []
         thread._jwLambdaArgument.push(arg)
-        if (this.proc) thread.procedures = {...this.proc, ...thread.procedures}
+        if (this.procedureFactories) {
+            thread.procedures = {
+                ...Object.fromEntries(Object.entries(this.procedureFactories).map(
+                    ([key, factory]) => [key, thread.procedures.hasOwnProperty(key) ? null : factory(thread)]
+                )),
+                ...thread.procedures
+            }
+            thread.procedureFactories = {...this.procedureFactories, ...thread.procedureFactories}
+        }
         this.timesExecuted++
         let output = (yield* this.func(arg, thread, target, runtime, stage, this) ?? "")
         thread._jwLambdaArgument.pop()

--- a/src/extensions/jwLambda/index.js
+++ b/src/extensions/jwLambda/index.js
@@ -70,6 +70,7 @@ class LambdaType {
         if (this.procedureFactories) {
             thread.procedures = {
                 ...Object.fromEntries(Object.entries(this.procedureFactories).map(
+                    // Only call the factory if the procedure doesn't already exist in `thread.procedures`
                     ([key, factory]) => [key, thread.procedures.hasOwnProperty(key) ? null : factory(thread)]
                 )),
                 ...thread.procedures


### PR DESCRIPTION
### Resolves

#194

### Proposed Changes

Stores references to procedure factories after a thread finishes compiling, and makes the Lambda extension use these factories to execute procedures in the proper thread.

### Reason for Changes

Without a fix, lambdas could cause unpredictable execution behavior with custom blocks.

---

~~I _STILL_ cannot figure out how to get a local PenguinMod instance running, so I have been unable to test this. Would appreciate if someone else could. An example to test with is uploaded in [the Discord bug reports post](https://discord.com/channels/1033551490331197462/1534046146530381855).~~

**Edit:** I finally [got it working](https://github.com/the-can-of-soup/pm_local_server_setup)! I have tested and confirmed that this pull request would fix the bug if merged (compare with the example output images in #194):

<img width="1193" height="845" alt="Screenshot of example program output displaying the same thread used for executing a custom block in a lambda as the thread executing the lambda" src="https://github.com/user-attachments/assets/1e7439b4-92d5-4fa3-8f0d-543dcd908841" />
